### PR TITLE
fix: fix for run.py and run_acc_calibration_error.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -126,6 +126,7 @@ class BrowsecampEval:
                         model=model_name,
                         system=SYSTEM_PROMPT_CN,
                         messages=messages[1:],
+                        max_tokens=8000,
                         temperature=0.6,
                         top_p=0.95,
                     )

--- a/run_acc_calibration_error.py
+++ b/run_acc_calibration_error.py
@@ -28,7 +28,10 @@ def process_model_data(model, input_path):
     for record in records:
         eval_res = record['eval_result'][0]
         is_correct = eval_res['is_correct'].lower()
-        confidence = int(eval_res['model_extracted_confidence'].split('%')[0])
+        try:
+            confidence = int(eval_res['model_extracted_confidence'].split('%')[0])
+        except:
+            confidence = 0
         
         # Count correct/incorrect/None results
         if is_correct == 'yes':


### PR DESCRIPTION
1 add the missed max_tokens attribution for Claude3.5-Sonnet
```
response = self.client.messages.create(
    model=model_name,
    system=SYSTEM_PROMPT_CN,
    messages=messages[1:],
    max_tokens=8000,  # fix. <-----
    temperature=0.6,
    top_p=0.95,
)
```
2 fix for run_acc_calibration_error.py
```
try:   # fix. <-----
    confidence = int(eval_res['model_extracted_confidence'].split('%')[0])
except:
    confidence = 0
```